### PR TITLE
Strip out null values for custom attributes

### DIFF
--- a/src/Resources/CustomAttributes.php
+++ b/src/Resources/CustomAttributes.php
@@ -18,7 +18,7 @@ class CustomAttributes extends Resource
      */
     public function __construct($attributes = [])
     {
-        $this->attributes = $attributes;
+        $this->attributes = array_filter($attributes, fn ($value) => !is_null($value));
     }
 
     /**

--- a/src/Resources/CustomAttributes.php
+++ b/src/Resources/CustomAttributes.php
@@ -18,7 +18,7 @@ class CustomAttributes extends Resource
      */
     public function __construct($attributes = [])
     {
-        $this->attributes = array_filter($attributes, fn ($value) => !is_null($value));
+        $this->attributes = array_filter($attributes, fn ($value) => ! is_null($value));
     }
 
     /**


### PR DESCRIPTION
This avoids sending an explicit null value for an optional field, causing the data type to be set to a string. An optional attribute for a date would be set to a string inadvertently.